### PR TITLE
user objectRef instead of simpleObject

### DIFF
--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,9 +1,17 @@
-import { builder } from '../builder'
+import { AllSelection } from 'kysely/dist/cjs/parser/select-parser';
+import { builder } from '../builder';
+import { DB } from '../types';
 
-export const UserType = builder.simpleObject('User', {
+export const UserType = builder.objectRef<AllSelection<DB, 'User'>>('User');
+
+UserType.implement({
   fields: (t) => ({
-    id: t.int(),
-    name: t.string({ nullable: true }),
-    email: t.string(),
+    id: t.exposeID('id'),
+    name: t.exposeString('name', { nullable: true }),
+    email: t.exposeString('email'),
+    initial: t.string({
+      nullable: true,
+      resolve: (user) => user.name?.slice(0, 1),
+    }),
   }),
-})
+});


### PR DESCRIPTION
Really like your cloudflare worker tutorial!  I'll probably link to it from the Pothos docs soon (I want to add a section for 3rd party tools and tutorials) 

simpleObjects are great for the simple cases, but are a dead end if you want to do anything more complex.  For tutorials I would recommend using an objectRef instead.  This is slightly more verbose to set up initially, but as soon as you want to add anything with a resolver, the simpleObject approach breaks down, and leaves users unsure how to extend their schema. 